### PR TITLE
Use ET to find weekday of alerts

### DIFF
--- a/query_helper.py
+++ b/query_helper.py
@@ -25,8 +25,8 @@ _GET_ALERTS_QUERY = '''
     FROM {closure_alerts_table} LEFT JOIN current_location_hours
     ON {closure_alerts_table}.drupal_location_id =
         current_location_hours.drupal_location_id
-    AND LEFT(TO_CHAR({closure_alerts_table}.polling_datetime, 'Day'), 3) =
-        current_location_hours.weekday;'''
+    AND LEFT(TO_CHAR({closure_alerts_table}.polling_datetime AT TIME ZONE
+        'America/New_York', 'Day'), 3) = current_location_hours.weekday;'''
 
 
 def build_get_alerts_query(hours_table, closure_alerts_table):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-nypl-py-utils==1.0.1
+nypl-py-utils==1.0.4
 redshift-connector


### PR DESCRIPTION
Fix 3 bugs:

1) The polling datetime is stored in UTC and the last poll is at 10pm EST, which is the following day in UTC, causing the query to use the location hours for the wrong weekday. Specify ET timezone to fix this.
2) Some alerts apply to multiple locations. Group by alert id and location id instead of just alert id to fix this.
3) If a location's regular hours cannot be found, still check that the alert was active on the polling day.