### PR TITLE
Allow for system closure with NULL id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+## 2026-01-14
+- Account for system-wide closures with NULL location id
+
 ## 2025-09-22
 - Update to use v2 closure alerts table and schema

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -33,10 +33,12 @@ def get_closures(alerts_df):
         raise LocationClosureAggregatorError("Polling occurred over multiple days")
 
     closures = []
-    for ids, alert_group in alerts_df.groupby(["alert_id", "location_id"]):
+    for ids, alert_group in alerts_df.groupby(
+        ["alert_id", "location_id"], dropna=False
+    ):
         # These are fake alerts created by the LocationClosureAlertPoller for
         # the purpose of recording each polling datetime
-        if ids[0] == "location_closure_alert_poller":
+        if ids[1] == "location_closure_alert_poller":
             continue
 
         # We assume the most recently polled version of the alert is the most
@@ -62,7 +64,7 @@ def get_closures(alerts_df):
             ):
                 closure["closure_start"] = None
                 closure["closure_end"] = None
-                closure["is_full_day"] = True
+                closure["is_full_day"] = None if pd.isnull(ids[1]) else True
                 closures.append(closure)
             continue
 

--- a/query_helper.py
+++ b/query_helper.py
@@ -9,9 +9,9 @@ _GET_ALERTS_QUERY = """
         extended_closing, alert_start, alert_end, polling_datetime,
         regular_open, regular_close
     FROM {closure_alerts_table} LEFT JOIN current_location_hours
-    ON {closure_alerts_table}.location_id = current_location_hours.location_id
-    AND TO_CHAR({closure_alerts_table}.polling_datetime AT TIME ZONE
-        'America/New_York', 'Day') = current_location_hours.weekday;"""
+        ON {closure_alerts_table}.location_id = current_location_hours.location_id
+        AND TO_CHAR({closure_alerts_table}.polling_datetime AT TIME ZONE
+            'America/New_York', 'Day') = current_location_hours.weekday;"""
 
 _INSERT_QUERY = """
     INSERT INTO {closures_table} (

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -1,6 +1,5 @@
 import json
 import lambda_function
-import os
 import pandas as pd
 import pytest
 
@@ -460,6 +459,41 @@ class TestLambdaFunction:
                 "closure_start": ["09:00:00", "09:00:00"],
                 "closure_end": ["17:00:00", "17:00:00"],
                 "is_full_day": [True, True],
+            }
+        ).values.tolist()
+
+        assert lambda_function.get_closures(_FULL_DF) == _CLOSURES
+
+    def test_system_closure(self, test_instance):
+        _ALERTS_DF = pd.DataFrame(
+            {
+                "location_id": [None] * 3,
+                "name": [None] * 3,
+                "alert_id": ["12"] * 3,
+                "closed_for": ["NYPL is closed"] * 3,
+                "extended_closing": [False] * 3,
+                "alert_start": ["2023-01-01 00:00:00-04"] * 3,
+                "alert_end": ["2023-01-02 00:00:00-04"] * 3,
+                "polling_datetime": get_polling_times(10, 13),
+                "regular_open": [None] * 3,
+                "regular_close": [None] * 3,
+            }
+        )
+        _FULL_DF = convert_df_types(
+            pd.concat([_BASE_ALERTS_DF, _ALERTS_DF], ignore_index=True)
+        )
+
+        _CLOSURES = pd.DataFrame(
+            {
+                "location_id": [None],
+                "name": [None],
+                "alert_id": ["12"],
+                "closed_for": ["NYPL is closed"],
+                "is_extended_closure": [False],
+                "closure_date": ["2023-01-01"],
+                "closure_start": [None],
+                "closure_end": [None],
+                "is_full_day": [None],
             }
         ).values.tolist()
 


### PR DESCRIPTION
This also means `is_full_day` could be NULL, as system-wide events won't have corresponding regular hours. We might be able to infer based on the length of the closure, but I think it's fine as is for now, especially considering this data is reviewed by hand.