### PR TITLE
Infer whether system closure was full day or not

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -2,7 +2,7 @@ import json
 import os
 import pandas as pd
 
-from datetime import datetime
+from datetime import datetime, time
 from nypl_py_utils.classes.kms_client import KmsClient
 from nypl_py_utils.classes.redshift_client import RedshiftClient
 from nypl_py_utils.functions.config_helper import load_env_file
@@ -67,13 +67,13 @@ def get_closures(alerts_df):
                 and last_alert["alert_end"].date() >= polling_date
             ):
                 # Clamp the closure to the current date
-                closure["closure_start"] = (
-                    max(day_start, last_alert["alert_start"]).time().isoformat()
-                )
-                closure["closure_end"] = (
-                    min(day_end, last_alert["alert_end"]).time().isoformat()
-                )
-                closure["is_full_day"] = None
+                closure_start = max(day_start, last_alert["alert_start"]).time()
+                closure_end = min(day_end, last_alert["alert_end"]).time()
+                closure["closure_start"] = closure_start.isoformat()
+                closure["closure_end"] = closure_end.isoformat()
+                closure["is_full_day"] = closure_start <= time(
+                    0, 0, 59
+                ) and closure_end >= time(23, 59, 0)
                 closures.append(closure)
             continue
 

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -467,16 +467,18 @@ class TestLambdaFunction:
     def test_system_closure(self, test_instance):
         _ALERTS_DF = pd.DataFrame(
             {
-                "location_id": [None] * 3,
-                "name": [None] * 3,
-                "alert_id": ["12"] * 3,
-                "closed_for": ["NYPL is closed"] * 3,
-                "extended_closing": [False] * 3,
-                "alert_start": ["2023-01-01 00:00:00-05"] * 3,
-                "alert_end": ["2023-01-03 23:59:59-05"] * 3,
-                "polling_datetime": get_polling_times(10, 13),
-                "regular_open": [None] * 3,
-                "regular_close": [None] * 3,
+                "location_id": [None] * 6,
+                "name": [None] * 6,
+                "alert_id": ["12"] * 3 + ["13"] * 3,
+                "closed_for": ["System full closure"] * 3 + ["System part closure"] * 3,
+                "extended_closing": [False] * 6,
+                "alert_start": ["2023-01-01 00:00:59-05"] * 6,
+                "alert_end": (
+                    ["2023-01-01 23:59:00-05"] * 3 + ["2023-01-01 11:00:00-05"] * 3
+                ),
+                "polling_datetime": get_polling_times(10, 13) * 2,
+                "regular_open": [None] * 6,
+                "regular_close": [None] * 6,
             }
         )
         _FULL_DF = convert_df_types(
@@ -485,15 +487,15 @@ class TestLambdaFunction:
 
         _CLOSURES = pd.DataFrame(
             {
-                "location_id": [None],
-                "name": [None],
-                "alert_id": ["12"],
-                "closed_for": ["NYPL is closed"],
-                "is_extended_closure": [False],
-                "closure_date": ["2023-01-01"],
-                "closure_start": ["00:00:00"],
-                "closure_end": ["23:59:59"],
-                "is_full_day": [None],
+                "location_id": [None, None],
+                "name": [None, None],
+                "alert_id": ["12", "13"],
+                "closed_for": ["System full closure", "System part closure"],
+                "is_extended_closure": [False, False],
+                "closure_date": ["2023-01-01", "2023-01-01"],
+                "closure_start": ["00:00:59", "00:00:59"],
+                "closure_end": ["23:59:00", "11:00:00"],
+                "is_full_day": [True, False],
             }
         ).values.tolist()
 


### PR DESCRIPTION
If the alert starts the day at 00:00 and ends at 23:59, it's a full day closure. Otherwise, we count it as a partial day closure. This could technically be wrong (e.g. if an alert started at 1am and ended at 11pm), but in reality it's likely accurate because when the alerts are set up, the admin is unlikely to use non-standard times for full-day alerts.